### PR TITLE
login_page_create #14

### DIFF
--- a/nuxt/pages/login/index.vue
+++ b/nuxt/pages/login/index.vue
@@ -1,0 +1,55 @@
+<template>
+  <v-container>
+    <v-card width="400px" class="mx-auto mt-5">
+      <v-card-title>
+        <h2>
+          ログイン
+        </h2>
+      </v-card-title>
+      <v-card-text>
+        <v-form ref="form" lazy-validation>
+          <v-text-field
+            v-model="email"
+            prepend-icon="mdi-email"
+            label="メールアドレス"
+          />
+          <v-text-field
+            v-model="password"
+            prepend-icon="mdi-lock"
+            :append-icon="toggle.icon"
+            :type="toggle.type"
+            autocomplete=“on”
+            @click:append="show = !show"
+            label="パスワード"
+          />
+          <v-card-actions>
+            <v-btn
+              color="light-green"
+              class="white--text"
+              @click="login"
+            >
+              ログイン
+            </v-btn>
+          </v-card-actions>
+        </v-form>
+      </v-card-text>
+    </v-card>
+  </v-container>
+</template>
+
+<script>
+export default {
+  data(){
+    return {
+      show: false
+    }
+  },
+  computed: {
+    toggle () {
+      const icon = this.show ? 'mdi-eye' : 'mdi-eye-off'
+      const type = this.show ? 'text' : 'password'
+      return { icon, type }
+    }
+  }
+}
+</script>

--- a/nuxt/pages/login/index.vue
+++ b/nuxt/pages/login/index.vue
@@ -19,7 +19,7 @@
             :append-icon="toggle.icon"
             :type="toggle.type"
             autocomplete=“on”
-            @click:append="show = !show"
+            @click:append="passShow = !passShow"
             label="パスワード"
           />
           <v-card-actions>
@@ -41,13 +41,13 @@
 export default {
   data(){
     return {
-      show: false
+      passShow: false
     }
   },
   computed: {
     toggle () {
-      const icon = this.show ? 'mdi-eye' : 'mdi-eye-off'
-      const type = this.show ? 'text' : 'password'
+      const icon = this.passShow ? 'mdi-eye' : 'mdi-eye-off'
+      const type = this.passShow ? 'text' : 'password'
       return { icon, type }
     }
   }


### PR DESCRIPTION
#why
- ログイン画面のUIを実装するため。

#what
- ログイン画面のUI
- パスワードの表示・非表示切り替え機能。

<img width="1438" alt="スクリーンショット 2021-10-03 14 27 06" src="https://user-images.githubusercontent.com/64937985/135741242-9ce38f78-a5a9-44f9-bfba-cc001690274f.png">

close #14 

