### PR TITLE
create_calendar_page #16

### DIFF
--- a/nuxt/package-lock.json
+++ b/nuxt/package-lock.json
@@ -5400,6 +5400,14 @@
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
     },
+    "data-fns": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/data-fns/-/data-fns-0.1.8.tgz",
+      "integrity": "sha512-3aC+mM92aUWsTx3lYD9el6RUZqaQceQeUw16de/cb9gyjp/CJ3yekYtsxQOYQoPAM2+kgfp1Km6zkzh5Q4+EYA==",
+      "requires": {
+        "unit-fns": "^0.1.6"
+      }
+    },
     "data-urls": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
@@ -5438,6 +5446,11 @@
           }
         }
       }
+    },
+    "date-fns": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.24.0.tgz",
+      "integrity": "sha512-6ujwvwgPID6zbI0o7UbURi2vlLDR9uP26+tW6Lg+Ji3w7dd0i3DOcjcClLjLPranT60SSEFBwdSyYwn/ZkPIuw=="
     },
     "de-indent": {
       "version": "1.0.2",
@@ -14523,6 +14536,11 @@
       "requires": {
         "imurmurhash": "^0.1.4"
       }
+    },
+    "unit-fns": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/unit-fns/-/unit-fns-0.1.7.tgz",
+      "integrity": "sha512-A6fT2bPCKjryr//T8X+euo2g9e5VRGIwOmLHb9bSasMBdKWQ+By3OwXkwTJbK8C6kUmJnbSCcJCNxJkkmKS15A=="
     },
     "universalify": {
       "version": "2.0.0",

--- a/nuxt/package.json
+++ b/nuxt/package.json
@@ -14,6 +14,8 @@
   "dependencies": {
     "@nuxtjs/axios": "^5.13.6",
     "core-js": "^3.15.1",
+    "data-fns": "^0.1.8",
+    "date-fns": "^2.24.0",
     "nuxt": "^2.15.7",
     "vuetify": "^2.5.5"
   },

--- a/nuxt/pages/calendar/index.vue
+++ b/nuxt/pages/calendar/index.vue
@@ -62,7 +62,7 @@
         <v-sheet class="flex">
         <v-calendar
           ref="calendar"
-          v-model="value"
+          v-model="dateValue"
           locale="ja-jp"
         ></v-calendar>
       </v-sheet>
@@ -76,13 +76,13 @@ import { format } from 'date-fns';
 export default {
   data() {
     return {
-       dateValue: format(new Date(), 'yyyy/MM/dd'),
+       dateValue: new Date(),
        isFollow: false
     }
   },
   computed: {
     calendarTitle() {
-        return format(new Date(this.dateValue), 'yyyy年 M月');
+        return format(this.dateValue, 'yyyy年 M月');
     },
     toggle(){
       const buttonColor = this.isFollow ? 'light-gray' : 'light-blue'

--- a/nuxt/pages/calendar/index.vue
+++ b/nuxt/pages/calendar/index.vue
@@ -1,0 +1,94 @@
+<template>
+  <div>
+    <v-sheet height="6vh" class="d-flex align-center" color="grey lighten-1">
+      <v-btn icon @click="$refs.calendar.prev()">
+        <v-icon>mdi-chevron-left</v-icon>
+      </v-btn>
+      <v-btn icon @click="$refs.calendar.next()">
+        <v-icon>mdi-chevron-right</v-icon>
+      </v-btn>
+      <v-toolbar-title>{{ calendarTitle }}</v-toolbar-title>
+    </v-sheet>
+    <v-sheet height="94vh" class="d-flex">
+        <v-sheet width="200px">
+          <v-list dense>
+            <v-list-item>
+              <v-list-item-content>
+                <v-subheader>imamura akito</v-subheader>
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-btn 
+                  :color="toggle.buttonColor"
+                  class="white--text"
+                  small
+                  @click="isFollow = !isFollow"
+                >
+                    {{ toggle.followStatus }}
+                </v-btn>
+              </v-list-item-action>
+            </v-list-item>
+              <v-list-item>
+                <v-list-item-content>
+                    <v-subheader>profile</v-subheader>
+                </v-list-item-content>
+              </v-list-item>
+              <v-list-item>
+                <v-subheader>
+                  プログラミング学習中！<br>
+                  気軽に読んでください！<br>
+                  仲良くしてくださいね！！
+                </v-subheader>
+              </v-list-item>
+            <v-list-item-group style="height:50px" class="mt-5">
+              <v-list-item>
+                <v-list-item-content class="pa-1">
+                  <v-checkbox
+                    class="pb-2 pt-2"
+                    label="my favorite"
+                  ></v-checkbox>
+                  <v-checkbox
+                    class="pb-2"
+                    label="follower's diaries"
+                  ></v-checkbox>
+                  <v-checkbox
+                    class="pb-2"
+                    label="only my diaries"
+                  ></v-checkbox>
+                </v-list-item-content>
+              </v-list-item>
+            </v-list-item-group>
+          </v-list>
+        </v-sheet>
+        <v-sheet class="flex">
+        <v-calendar
+          ref="calendar"
+          v-model="value"
+          locale="ja-jp"
+        ></v-calendar>
+      </v-sheet>
+    </v-sheet>
+  </div>
+</template>
+
+<script>
+import { format } from 'date-fns';
+
+export default {
+  data() {
+    return {
+       dateValue: format(new Date(), 'yyyy/MM/dd'),
+       isFollow: false
+    }
+  },
+  computed: {
+    calendarTitle() {
+        return format(new Date(this.dateValue), 'yyyy年 M月');
+    },
+    toggle(){
+      const buttonColor = this.isFollow ? 'light-gray' : 'light-blue'
+      const followStatus = this.isFollow ? 'フォロー済' : 'フォローする'
+      return { buttonColor, followStatus }
+    }
+  },
+}
+</script>


### PR DESCRIPTION
# why
カレンダーページのフロント画面の作成のため。

# what
・カレンダーページのフロント画面のビュー
・カレンダーの月の変更ボタン
・フォローボタンの切り替えの機能。

![image](https://user-images.githubusercontent.com/64937985/135848356-b467e650-2e7e-4914-a4c3-01410039870b.png)

close #16 
