### PR TITLE
logout_function #40

### DIFF
--- a/nuxt/layouts/default.vue
+++ b/nuxt/layouts/default.vue
@@ -14,6 +14,7 @@
           :to="item.to"
           router
           exact
+          @click="userLogout"
         >
           <v-list-item-action>
             <v-icon>{{ item.icon }}</v-icon>
@@ -98,19 +99,22 @@ export default {
       items: [
         {
           icon: 'mdi-apps',
-          title: 'Welcome',
+          title: 'logout',
           to: '/'
         },
-        {
-          icon: 'mdi-chart-bubble',
-          title: 'Inspire',
-          to: '/inspire'
-        }
       ],
       miniVariant: false,
       right: true,
       rightDrawer: false,
       title: 'Vuetify.js'
+    }
+  },
+  methods:{
+    userLogout(){
+      localStorage.setItem('access-token', "")
+      localStorage.setItem('client', "")
+      localStorage.setItem('uid', "")
+      localStorage.setItem('token-type',"")
     }
   }
 }

--- a/nuxt/nuxt.config.js
+++ b/nuxt/nuxt.config.js
@@ -87,6 +87,7 @@ export default {
       local: {
         endpoints: {
           login: { url: '/api/v1/auth/sign_in', method: 'post', propertyName: 'token' },
+          logout: false,
           user: false
         },
       }


### PR DESCRIPTION
# why
ログアウト機能の作成のため

# what
・ログアウト機能(this.$auth.logout()でローカルストレージのトークンが削除されなかったので、トークンに空文字を再セットする方針で実装)

※header周りはこの後の#20のタイミングで修正する
※簡易なプログラムのため自分でマージする。

close #40 